### PR TITLE
Use pre-commit to maintain the pre-commit example in the README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,12 +49,14 @@ repos:
     hooks:
       - id: "isort"
 
+# START_README_EXAMPLE_BLOCK
   - repo: "https://github.com/pycqa/flake8"
     rev: "7.3.0"
     hooks:
       - id: "flake8"
         additional_dependencies:
           - "flake8-toml-config==1.0.0"
+# END_README_EXAMPLE_BLOCK
           - "flake8-bugbear==24.12.12"
 
   - repo: "https://github.com/editorconfig-checker/editorconfig-checker"
@@ -76,3 +78,12 @@ repos:
     rev: "v1.0.0"
     hooks:
       - id: "verify-consistent-pyproject-toml-python-requirements"
+
+  - repo: "local"
+    hooks:
+      - id: "update-readme-pre-commit-example"
+        name: "Update the pre-commit config in the README"
+        language: "python"
+        entry: "python assets/update_readme_pre_commit_example.py"
+        always_run: true
+        pass_filenames: false

--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,7 @@ pre-commit usage
 
 Add this plugin as an additional dependency:
 
+..  START_EXAMPLE_PRE_COMMIT_BLOCK
 ..  code-block:: yaml
 
     - repo: "https://github.com/pycqa/flake8"
@@ -122,6 +123,7 @@ Add this plugin as an additional dependency:
         - id: "flake8"
           additional_dependencies:
             - "flake8-toml-config==1.0.0"
+..  END_EXAMPLE_PRE_COMMIT_BLOCK
 
 
 Note that the ``pre-commit autoupdate`` command, and `pre-commit.ci`_,

--- a/assets/update_readme_pre_commit_example.py
+++ b/assets/update_readme_pre_commit_example.py
@@ -1,0 +1,55 @@
+# This file is a part of flake8-toml-config.
+# https://github.com/kurtmckee/flake8-toml-config
+# Copyright 2025 Kurt McKee <contactme@kurtmckee.org>
+# SPDX-License-Identifier: MIT
+
+import pathlib
+import re
+import sys
+import textwrap
+import tomllib
+
+FILES_NOT_MODIFIED = 0
+FILES_MODIFIED = 1
+
+ROOT = pathlib.Path(__file__).parent.parent
+PRE_COMMIT_YAML = (ROOT / ".pre-commit-config.yaml").resolve()
+PYPROJECT_TOML = (ROOT / "pyproject.toml").resolve()
+README_RST = (ROOT / "README.rst").resolve()
+
+
+def main() -> int:
+    # Extract the YAML example to embed in the README.
+    yaml = PRE_COMMIT_YAML.read_text(encoding="utf-8")
+    start_line = "# START_README_EXAMPLE_BLOCK\n"
+    end_line = "# END_README_EXAMPLE_BLOCK"
+    start = yaml.find(start_line) + len(start_line)
+    end = yaml.rfind("\n", start, yaml.find(end_line, start))
+    example = textwrap.dedent(yaml[start:end])
+
+    # Inject the current project version.
+    project_info = tomllib.loads(PYPROJECT_TOML.read_text())
+    version = project_info["project"]["version"]
+    example = re.sub(r"""(?<=flake8-toml-config==)[0-9.]+""", version, example)
+
+    # Prepare the example for injection.
+    block = "..  code-block:: yaml\n\n" + textwrap.indent(example, " " * 4)
+
+    # Determine the text boundaries of the source code in the README.
+    rst = README_RST.read_text(encoding="utf-8")
+    start_line = "..  START_EXAMPLE_PRE_COMMIT_BLOCK\n"
+    end_line = "..  END_EXAMPLE_PRE_COMMIT_BLOCK"
+    start = rst.find(start_line) + len(start_line)
+    end = rst.rfind("\n", start, rst.find(end_line, start))
+
+    # Inject the example and determine if the README needs to be overwritten.
+    new_rst = rst[:start] + block + rst[end:]
+    if new_rst != rst:
+        README_RST.write_text(new_rst, encoding="utf-8", newline="\n")
+        return FILES_MODIFIED
+
+    return FILES_NOT_MODIFIED
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/changelog.d/20250813_082930_kurtmckee_maintain_readme.rst
+++ b/changelog.d/20250813_082930_kurtmckee_maintain_readme.rst
@@ -1,0 +1,4 @@
+Development
+-----------
+
+*   Use pre-commit to keep the pre-commit example in the README update-to-date.


### PR DESCRIPTION
Development
-----------

*   Use pre-commit to keep the pre-commit example in the README update-to-date.
